### PR TITLE
Added a config variable for database name called MONGODB_DB_NAME

### DIFF
--- a/mongodbstorage/operation_primitives.py
+++ b/mongodbstorage/operation_primitives.py
@@ -17,7 +17,8 @@ def get_timestamp():
     return datetime.now(tz.tzutc())
 
 MONGO_CLIENT = MongoClient(os.environ['MONGODB_DB_HOST'], int(os.environ['MONGODB_DB_PORT']), tz_aware=True)
-MONGO_DB = MONGO_CLIENT[os.environ['APP_NAME']]
+MONGODB_DB_NAME = os.environ['MONGODB_DB_NAME'] if 'MONGODB_DB_NAME' in os.environ else os.environ['APP_NAME'] 
+MONGO_DB = MONGO_CLIENT[MONGODB_DB_NAME]
 if 'MONGODB_DB_USERNAME' in os.environ: 
     MONGO_DB.authenticate(os.environ['MONGODB_DB_USERNAME'], os.environ['MONGODB_DB_PASSWORD'])
 


### PR DESCRIPTION
In operation_primatives.py there was an assumption that the name of the mongo database was the same as the value of the APP_NAME environmental variable. I added the option of explicitly specifying the name of the database. The scenario I wished to enable was the one where multiple applications share a single database, which is particularly desirable when you are using a hosted MongoDB offering that is charged for by the database. This new environmental variable is called MONGODB_DB_NAME. If it's not specified then APP_NAME will be used.
